### PR TITLE
[TASK] Add ViewHelper to get full page database record

### DIFF
--- a/Classes/ViewHelpers/GetDatabaseRecordViewHelper.php
+++ b/Classes/ViewHelpers/GetDatabaseRecordViewHelper.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace B13\Backendpreviews\ViewHelpers;
+
+/*
+ * This file is part of TYPO3 CMS-extension backendpreviews by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+use TYPO3\CMS\Core\Database\Query\Restriction\WorkspaceRestriction;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
+/**
+ * Class GetDatabaseRecordViewHelper
+ *
+ * ViewHelper to get database records by uid.
+ *
+ * @package B13\Backendpreviews\ViewHelpers
+ */
+class GetDatabaseRecordViewHelper extends AbstractViewHelper
+{
+
+    use CompileWithContentArgumentAndRenderStatic;
+
+    /**
+     * Default table
+     */
+    const DEFAULT_TABLE = 'tt_content';
+
+    /**
+     * Initialize arguments.
+     *
+     * @return void
+     * @api
+     */
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerArgument(
+            'table',
+            'string',
+            'The database table to fetch a single record from. Default: tt_content',
+            false,
+            'tt_content'
+        );
+        $this->registerArgument(
+            'uidList',
+            'string',
+            'The record uid(s).',
+            true
+        );
+    }
+
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param \TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface $renderingContext
+     * @return array
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): array
+    {
+        $table = $arguments['table'] ?? self::DEFAULT_TABLE;
+        $queryBuilder = self::getQueryBuilder($table);
+
+        $result = $queryBuilder
+            ->select('*')
+            ->from($table)
+            ->where(
+                $queryBuilder->expr()->in('uid', $queryBuilder->createNamedParameter($arguments['uidList'])),
+            )
+            ->execute()
+            ->fetchAll();
+        return $result;
+    }
+
+    protected static function getQueryBuilder(string $table): QueryBuilder
+    {
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($table);
+        $queryBuilder->getRestrictions()
+            ->removeAll()
+            ->add(GeneralUtility::makeInstance(DeletedRestriction::class))
+            ->add(GeneralUtility::makeInstance(WorkspaceRestriction::class, (int)$GLOBALS['BE_USER']->workspace));
+        return $queryBuilder;
+    }
+
+}


### PR DESCRIPTION
This is used to display information on linked pages, or data from linked pages (like selected authors, products, events, etc.)