### PR TITLE
[FEATURE] Remove default header output from backend previews

### DIFF
--- a/Classes/Backend/Preview/StandardContentPreviewRenderer.php
+++ b/Classes/Backend/Preview/StandardContentPreviewRenderer.php
@@ -17,6 +17,13 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class StandardContentPreviewRenderer extends \TYPO3\CMS\Backend\Preview\StandardContentPreviewRenderer
 {
+    public function renderPageModulePreviewHeader(GridColumnItem $item): string
+    {
+        // we do not add any output by default
+        // this removes the default output of header, subheader, date, header_layout
+        return '';
+    }
+
     public function renderPageModulePreviewContent(GridColumnItem $item): string
     {
         $record = $item->getRecord();

--- a/Resources/Private/Layouts/Default.html
+++ b/Resources/Private/Layouts/Default.html
@@ -20,6 +20,9 @@
 			</f:render>
 		</span><br>
 	</f:render>
+	<f:render section="Header" optional="true">
+		<f:render partial="Defaults/Header" arguments="{_all}" />
+	</f:render>
 	<f:render section="Subheader" optional="true">
 		<f:render partial="Defaults/Subheader" arguments="{_all}" />
 	</f:render>

--- a/Resources/Private/Layouts/DefaultWithLink.html
+++ b/Resources/Private/Layouts/DefaultWithLink.html
@@ -20,6 +20,9 @@
 			</f:render>
 		</span><br>
 	</f:render>
+	<f:render section="Header" optional="true">
+		<f:render partial="Defaults/Header" arguments="{_all}" />
+	</f:render>
 	<f:render section="Subheader" optional="true">
 		<f:render partial="Defaults/Subheader" arguments="{_all}" />
 	</f:render>

--- a/Resources/Private/Partials/Defaults/Header.html
+++ b/Resources/Private/Partials/Defaults/Header.html
@@ -1,0 +1,8 @@
+<html
+        xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+        data-namespace-typo3-fluid="true"
+>
+
+<f:if condition="{header}"><span class="b_header">{header}</span><br></f:if>
+
+</html>

--- a/Resources/Public/Backend/Css/Skin/backendpreviews.css
+++ b/Resources/Public/Backend/Css/Skin/backendpreviews.css
@@ -30,6 +30,10 @@
 	font-weight: bold;
 }
 
+.b_header {
+	font-weight: bold;
+}
+
 .b_subheader {
 	font-style: italic;
 }


### PR DESCRIPTION
This removes the default preview header of each content element to make custom previews more flexible. In v12 the subheader was added as a fourth “fixed” text to every element preview, making custom previews more complicated (if the subeader field was used for something else). We include header/subheader in the default preview Layout template, so updating should not affect most instances where current previews rely on the header field of an element to be displayed “by default”.