### PR TITLE
[FEATURE] Add TYPO3 v13 compatibility and resolve all files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "php": "^7.4 || ~8.0",
-    "typo3/cms-core": "^10.4 || ^11.5 || ^12.1"
+    "typo3/cms-core": "^10.4 || ^11.5 || ^12.1 || ^13.0"
   },
   "suggest": {
     "b13/listelements": "*"


### PR DESCRIPTION
This change makes use of the logic of resolving TCA type=file relations of tt_content elements automatically by utilizing https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-98479-NewTCATypeFile.html#feature-98479-new-tca-type-file

In addition, a fallback for TYPO3 v11 and below is kept by checking if no type=file column is found.

Also, a small removal of getLL() is changed to sL(), adding TYPO3 v13 compatibility.