### PR TITLE
[BUGFIX] Fix TYPO3 14 deprecation

### DIFF
--- a/Classes/Service/DatabaseRowService.php
+++ b/Classes/Service/DatabaseRowService.php
@@ -38,7 +38,7 @@ class DatabaseRowService
         if ((new Typo3Version())->getMajorVersion() < 14) {
             $editAccess = $this->getBackendUser()->recordEditAccessInternals($record->getMainType(), $record->getRawRecord()->toArray());
         } else {
-            $editAccess = $this->getBackendUser()->recordEditAccessInternals($record->getMainType(), $record);
+            $editAccess = $this->getBackendUser()->checkRecordEditAccess($record->getMainType(), $record);
         }
         if ($editAccess) {
             $urlParameters = [


### PR DESCRIPTION
`recordEditAccessInternals` is deprecation and replaced with the method `checkRecordEditAccess`. This call is already in an if branch that only is called with TYPO3 14 and onwards, therefore we can already use the new method without breaking compatibility with older TYPO3 versions.

See: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.2/Deprecation-108568-BackendUserAuthenticationRecordEditAccessInternals.html#deprecation-108568-backenduserauthentication-recordeditaccessinternals-and-errormsg