### PR TITLE
[FEATURE] Fallback icon for non-image media files

### DIFF
--- a/Resources/Private/Partials/Media/Image.html
+++ b/Resources/Private/Partials/Media/Image.html
@@ -1,15 +1,33 @@
 <html
 	xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+	xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
 	data-namespace-typo3-fluid="true"
 >
 
 <f:if condition="{image.uid}">
-	<f:image
-		src="{image.uid}" treatIdAsReference="1"
-		height="64"
-		class="b_image {f:if(condition: image.properties.hidden, then: 'b_image--hidden')}"
-		cropVariant="{cropVariant}"
-	/>
+	<f:if condition="{image.type} == 2">
+		<f:then>
+			<f:image
+				src="{image.uid}" treatIdAsReference="1"
+				height="64"
+				class="b_image {f:if(condition: image.properties.hidden, then: 'b_image--hidden')}"
+				cropVariant="{cropVariant}"
+			/>
+		</f:then>
+		<f:else>
+			<f:switch expression="{image.type}">
+				<f:case value="4"><f:variable name="iconIdentifier" value="mimetypes-media-video"/></f:case>
+				<f:case value="3"><f:variable name="iconIdentifier" value="mimetypes-media-audio"/></f:case>
+				<f:defaultCase><f:variable name="iconIdentifier" value="mimetypes-other-other"/></f:defaultCase>
+			</f:switch>
+			<span
+				class="b_image b_image--icon {f:if(condition: image.properties.hidden, then: 'b_image--hidden')}"
+				title="{image.name}"
+			>
+				<core:icon identifier="{iconIdentifier}" size="large"/>
+			</span>
+		</f:else>
+	</f:if>
 </f:if>
 
 </html>

--- a/Resources/Public/Backend/Css/Skin/backendpreviews.css
+++ b/Resources/Public/Backend/Css/Skin/backendpreviews.css
@@ -47,6 +47,16 @@
 	margin-top: var(--spacing-image);
 }
 
+.b_image--icon {
+	display: inline-block;
+	vertical-align: top;
+}
+
+.b_image--icon .icon {
+	width: 64px;
+	height: 64px;
+}
+
 .b_tiles {
 	width: var(--tiles-width-default);
 	display: inline-block;


### PR DESCRIPTION
Media previews rendered files via `f:image` only. For non-image files (e.g. a video or audio file in the `media` field of a textmedia element) this breaks or leaves the preview empty.

## Changes
- `Media/Image.html`: branch on the file type — render `f:image` for images (type 2) and a TYPO3 `<core:icon>` fallback otherwise (`mimetypes-media-video` / `mimetypes-media-audio` / `mimetypes-other-other`).
- Add `.b_image--icon` styling so the fallback aligns with image previews.

Pure Fluid/CSS solution — no version-specific PHP (works on TYPO3 v10.4–v14). PHPStan v14 passes locally.

Resolves [BEXT-223](https://b13.atlassian.net/browse/BEXT-223).